### PR TITLE
Rename c0ct to c0cat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ cscope.*
 m0trace.*
 core.*
 c0cp
-c0ct
+c0cat
 c0isc_demo
 c0isc_reg
 c0rm

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ CFLAGS += -rdynamic
 ifneq ($(M0_SRC_DIR),)
 LFLAGS += -L$(M0_SRC_DIR)/motr/.libs -Wl,-rpath,$(M0_SRC_DIR)/motr/.libs
 LFLAGS += -L$(M0_SRC_DIR)/extra-libs/galois/src/.libs -Wl,-rpath,$(M0_SRC_DIR)/extra-libs/gf-complete/src/.libs
-CFLAGS += -I$(M0_SRC_DIR)
+CFLAGS += -I$(M0_SRC_DIR) -I$(M0_SRC_DIR)/extra-libs/galois/include
 endif
 
 SRC = perf.o buffer.o qos.o c0appz.o

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ FILE3 = './file3'
 
 #executables
 C0CP = c0cp
-C0CT = c0ct
+C0CT = c0cat
 C0RM = c0rm
 FGEN = fgen
 
@@ -86,7 +86,7 @@ CFLAGS += -I$(M0_SRC_DIR)
 endif
 
 SRC = perf.o buffer.o qos.o c0appz.o
-SRC_ALL = $(SRC) c0cp.o c0ct.o c0rm.o fgen.o \
+SRC_ALL = $(SRC) c0cp.o c0cat.o c0rm.o fgen.o \
 		c0isc_register.o c0isc_demo.o isc_libdemo.o
 
 all: $(C0CP) $(C0CT) $(C0RM) $(FGEN) isc-all
@@ -104,8 +104,8 @@ all: $(C0CP) $(C0CT) $(C0RM) $(FGEN) isc-all
 $(C0CP): $(SRC) c0cp.c
 	gcc $(SRC) c0cp.c -I/usr/include/motr $(CFLAGS) $(LFLAGS) -o $(C0CP)
 
-$(C0CT): $(SRC) c0ct.c
-	gcc $(SRC) c0ct.c -I/usr/include/motr $(CFLAGS) $(LFLAGS) -o $(C0CT)
+$(C0CT): $(SRC) c0cat.c
+	gcc $(SRC) c0cat.c -I/usr/include/motr $(CFLAGS) $(LFLAGS) -o $(C0CT)
 
 $(C0RM): $(SRC) c0rm.c
 	gcc $(SRC) c0rm.c -I/usr/include/motr $(CFLAGS) $(LFLAGS) -o $(C0RM)

--- a/c0cat.c
+++ b/c0cat.c
@@ -47,10 +47,10 @@ extern pthread_mutex_t qos_lock;	/* lock  qos_total_weight */
 
 char *prog;
 
-const char *help_c0ct_txt = "\
+const char *help_c0cat_txt = "\
 Usage:\n\
-  c0ct [-ptv] [-b [sz]] [-c n] idh idl file bsz fsz\n\
-  c0ct 1234 56789 file 1024 268435456\n\
+  c0cat [-ptv] [-b [sz]] [-c n] idh idl file bsz fsz\n\
+  c0cat 1234 56789 file 1024 268435456\n\
 \n\
 Copy object from the object store into file.\n\
 \n\
@@ -75,7 +75,7 @@ where n is 2 in 2+1 parity group configuration, 8 in 8+2 and so on.\n";
 
 int help()
 {
-	fprintf(stderr,"%s\n%s\n", help_c0ct_txt, c0appz_help_txt);
+	fprintf(stderr,"%s\n%s\n", help_c0cat_txt, c0appz_help_txt);
 	exit(1);
 }
 

--- a/scripts/c0appztest.sh
+++ b/scripts/c0appztest.sh
@@ -29,18 +29,18 @@ echo "Contiguous Mode!"
 set -x
 ./c0rm 21 21 -y
 ./c0cp 21 21 $TEST_FILE_256MB 1024 -fc 2
-./c0ct 21 21 $TEST_FILE_OUT 1024 $((256*1024*1024)) -c 2
+./c0cat 21 21 $TEST_FILE_OUT 1024 $((256*1024*1024)) -c 2
 ./c0cp 21 21 $TEST_FILE_1GB 1024 -fc 3
-./c0ct 21 21 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -c 3
+./c0cat 21 21 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -c 3
 set +x
 
 echo "Performance Mode!"
 set -x
 #default tier
 ./c0cp 21 21 $TEST_FILE_256MB 1024 -pfc 5
-./c0ct 21 21 $TEST_FILE_OUT 1024 $((256*1024*1024)) -pc 5
+./c0cat 21 21 $TEST_FILE_OUT 1024 $((256*1024*1024)) -pc 5
 ./c0cp 21 21 $TEST_FILE_1GB 1024 -pfc 3
-./c0ct 21 21 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
+./c0cat 21 21 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
 #tiers 123
 ./c0rm 21 221 -y
 ./c0rm 21 222 -y
@@ -51,12 +51,12 @@ set -x
 ./c0cp 21 221 $TEST_FILE_1GB 1024 -x 1 -pfc 3
 ./c0cp 21 222 $TEST_FILE_1GB 1024 -x 2 -pfc 3
 ./c0cp 21 223 $TEST_FILE_1GB 1024 -x 3 -pfc 3
-./c0ct 21 221 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -p
-./c0ct 21 222 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -p
-./c0ct 21 223 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -p
-./c0ct 21 221 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
-./c0ct 21 222 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
-./c0ct 21 223 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
+./c0cat 21 221 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -p
+./c0cat 21 222 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -p
+./c0cat 21 223 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -p
+./c0cat 21 221 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
+./c0cat 21 222 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
+./c0cat 21 223 $TEST_FILE_OUT 1024 $((1024*1024*1024)) -pc 3
 set +x
 
 echo "Asynchronous Mode!"

--- a/scripts/single_file_test
+++ b/scripts/single_file_test
@@ -28,7 +28,7 @@
 #executables
 c0cp='./c0cp'
 c0rm='./c0rm'
-c0ct='./c0ct'
+c0cat='./c0cat'
 fgen='./fgen'
 
 #files
@@ -89,8 +89,8 @@ test()
     	echo "error! file $c0cp is not executable nor found"
     	return 12
 	fi
-	if [[ ! -x "$c0ct" ]]; then
-    	echo "error! file $c0ct is not executable nor found"
+	if [[ ! -x "$c0cat" ]]; then
+    	echo "error! file $c0cat is not executable nor found"
     	return 13
 	fi
 	if [[ ! -x "$c0rm" ]]; then
@@ -126,7 +126,7 @@ test()
 	   	
 	#c0cat
 	rm -f m0trace.* # clean up  		
-	cmd="$c0ct $fid $ofp $bsz $fsz"
+	cmd="$c0cat $fid $ofp $bsz $fsz"
 	runc $cmd
 	if [[ $? -ne 0 ]]; then
 	  	#remove fid if possible
@@ -177,7 +177,7 @@ test()
 	   	
 	#c0cat
 	rm -f m0trace.* # clean up  		
-	cmd="$c0ct $fid $ofp $bsz $fsz"
+	cmd="$c0cat $fid $ofp $bsz $fsz"
 	runc $cmd
 	if [[ $? -ne 0 ]]; then
 	  	#remove fid if possible

--- a/scripts/single_node_test
+++ b/scripts/single_node_test
@@ -29,7 +29,7 @@
 #executables
 c0cp='./c0cp'
 c0rm='./c0rm'
-c0ct='./c0ct'
+c0cat='./c0cat'
 fgen='./fgen'
 
 #files
@@ -85,8 +85,8 @@ c0fidtest()
     	echo "error! file $c0cp is not executable nor found"
     	return 12
 	fi
-	if [[ ! -x "$c0ct" ]]; then
-    	echo "error! file $c0ct is not executable nor found"
+	if [[ ! -x "$c0cat" ]]; then
+    	echo "error! file $c0cat is not executable nor found"
     	return 13
 	fi
 	if [[ ! -x "$c0rm" ]]; then
@@ -125,10 +125,10 @@ c0fidtest()
 	   	
 		#c0cat
 		rm -f m0trace.* # clean up  		
-		$c0ct $fid $dwfile $bsz $cnt 2>> $log
+		$c0cat $fid $dwfile $bsz $cnt 2>> $log
 	   	if [[ $? -ne 0 ]]; then
 	   		echo
-	  		echo "$c0ct $fid $bsz $cnt > $dwfile 2>> $log"
+	  		echo "$c0cat $fid $bsz $cnt > $dwfile 2>> $log"
 	  		#remove fid if possible
 	  		$c0rm $fid 2>> $log 	  		
 	  		return 21

--- a/scripts/tiertest.sh
+++ b/scripts/tiertest.sh
@@ -29,9 +29,9 @@ set -x
 ./c0cp $id2 $FILE1 $bsz -b -pfx2 -c1 -a8
 ./c0cp $id3 $FILE1 $bsz -b -pfx3 -c1 -a8
 # read
-./c0ct $id1 $FILE2 $bsz $fsz -b -p -c1
-./c0ct $id2 $FILE2 $bsz $fsz -b -p -c1
-./c0ct $id3 $FILE2 $bsz $fsz -b -p -c1
+./c0cat $id1 $FILE2 $bsz $fsz -b -p -c1
+./c0cat $id2 $FILE2 $bsz $fsz -b -p -c1
+./c0cat $id3 $FILE2 $bsz $fsz -b -p -c1
 # delete
 ./c0rm $id1 -y 
 ./c0rm $id2 -y 


### PR DESCRIPTION
To be consistent with README and with well-known `cat` utility.