### PR TITLE
c0isc_demo: fix panic on m0_client_fini()

### DIFF
--- a/c0appz.c
+++ b/c0appz.c
@@ -882,6 +882,15 @@ int c0appz_isc_req_send_sync(struct c0appz_isc_req *req)
 	return req->cir_rc == 0 ? rc : req->cir_rc;
 }
 
+static void fop_fini_lock(struct m0_fop *fop)
+{
+	struct m0_rpc_machine *mach = m0_fop_rpc_machine(fop);
+
+	m0_rpc_machine_lock(mach);
+	m0_fop_fini(fop);
+	m0_rpc_machine_unlock(mach);
+}
+
 void c0appz_isc_req_fini(struct c0appz_isc_req *req)
 {
 	struct m0_fop *reply_fop;
@@ -889,8 +898,11 @@ void c0appz_isc_req_fini(struct c0appz_isc_req *req)
 	reply_fop = m0_rpc_item_to_fop(req->cir_fop.f_item.ri_reply);
 	if (reply_fop != NULL)
 		m0_fop_put_lock(reply_fop);
+	req->cir_fop.f_item.ri_reply = NULL;
 	m0_rpc_at_fini(&req->cir_isc_fop.fi_args);
 	m0_rpc_at_fini(&req->cir_isc_fop.fi_ret);
+	req->cir_fop.f_data.fd_data = NULL;
+	fop_fini_lock(&req->cir_fop);
 }
 
 /*

--- a/c0isc_demo.c
+++ b/c0isc_demo.c
@@ -364,6 +364,8 @@ int main(int argc, char **argv)
 		return -EINVAL;
 	}
 
+	m0trace_on = true;
+
 	/* initialize resources */
 	rc = c0appz_init(0);
 	if (rc != 0) {


### PR DESCRIPTION
```
$ ./c0isc_demo ping

Hello-world@<7300000000000001:27>
motr[31871]:  1130  ERROR  [rpc/item.c:1683:m0_rpc_item_xid_list_fini]  session=0x1e8d478 item=0x7ffc3f741648 [REQUEST/M0_ISCSERVICE_REQ_OPCODE(350)] ri_sm.sm_state=7
motr[31871]:   ff0  FATAL  [lib/assert.c:50:m0_panic]  panic: (m0_list_is_empty(head)) at m0_list_fini() (lib/list.c:38)  [git: sage-base-1.0-133-gfa45ae7bd]
Motr panic: (m0_list_is_empty(head)) at m0_list_fini() lib/list.c:38 (errno: 0) (last failed: none) [git: sage-base-1.0-133-gfa45ae7bd] pid: 31871
/data/motr/motr/.libs/libmotr.so.1(m0_arch_backtrace+0x20)[0x7fe80ab14280]
/data/motr/motr/.libs/libmotr.so.1(m0_arch_panic+0xe6)[0x7fe80ab14436]
/data/motr/motr/.libs/libmotr.so.1(+0x357bc4)[0x7fe80ab03bc4]
/data/motr/motr/.libs/libmotr.so.1(+0x35b81b)[0x7fe80ab0781b]
/data/motr/motr/.libs/libmotr.so.1(m0_rpc_item_xid_list_fini+0xce)[0x7fe80ab8dd2e]
/data/motr/motr/.libs/libmotr.so.1(m0_rpc_session_fini_locked+0x6e)[0x7fe80ab98d1e]
/data/motr/motr/.libs/libmotr.so.1(m0_rpc_session_fini+0x56)[0x7fe80ab98e36]
/data/motr/motr/.libs/libmotr.so.1(m0_rpc_link_fini+0x47)[0x7fe80ab91b37]
/data/motr/motr/.libs/libmotr.so.1(m0_reqh_service_ctx_fini+0xb6)[0x7fe80ab74706]
/data/motr/motr/.libs/libmotr.so.1(m0_reqh_service_ctx_destroy+0x11)[0x7fe80ab74b01]
/data/motr/motr/.libs/libmotr.so.1(+0x3bba80)[0x7fe80ab67a80]
/data/motr/motr/.libs/libmotr.so.1(m0_pools_service_ctx_destroy+0x52)[0x7fe80ab6a292]
/data/motr/motr/.libs/libmotr.so.1(+0x380d64)[0x7fe80ab2cd64]
/data/motr/motr/.libs/libmotr.so.1(+0x3f1876)[0x7fe80ab9d876]
/data/motr/motr/.libs/libmotr.so.1(m0_client_fini+0x138)[0x7fe80ab2edd8]
./c0isc_demo(c0appz_free+0x15)[0x406865]
./c0isc_demo(main+0x408)[0x403dd8]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7fe80a400555]
./c0isc_demo[0x404152]
Aborted (core dumped)
```

Solution: finalize fop at c0appz_isc_req_fini().

Closes #8.