### PR TITLE
c0isc_demo: fix min/max demo on singlenode cluster

### DIFF
--- a/c0appz.c
+++ b/c0appz.c
@@ -882,6 +882,15 @@ int c0appz_isc_req_send_sync(struct c0appz_isc_req *req)
 	return req->cir_rc == 0 ? rc : req->cir_rc;
 }
 
+static void fop_fini_lock(struct m0_fop *fop)
+{
+	struct m0_rpc_machine *mach = m0_fop_rpc_machine(fop);
+
+	m0_rpc_machine_lock(mach);
+	m0_fop_fini(fop);
+	m0_rpc_machine_unlock(mach);
+}
+
 void c0appz_isc_req_fini(struct c0appz_isc_req *req)
 {
 	struct m0_fop *reply_fop;
@@ -889,8 +898,11 @@ void c0appz_isc_req_fini(struct c0appz_isc_req *req)
 	reply_fop = m0_rpc_item_to_fop(req->cir_fop.f_item.ri_reply);
 	if (reply_fop != NULL)
 		m0_fop_put_lock(reply_fop);
+	req->cir_fop.f_item.ri_reply = NULL;
 	m0_rpc_at_fini(&req->cir_isc_fop.fi_args);
 	m0_rpc_at_fini(&req->cir_isc_fop.fi_ret);
+	req->cir_fop.f_data.fd_data = NULL;
+	fop_fini_lock(&req->cir_fop);
 }
 
 /*

--- a/c0isc_demo.c
+++ b/c0isc_demo.c
@@ -364,6 +364,8 @@ int main(int argc, char **argv)
 		return -EINVAL;
 	}
 
+	m0trace_on = true;
+
 	/* initialize resources */
 	rc = c0appz_init(0);
 	if (rc != 0) {

--- a/c0isc_demo.c
+++ b/c0isc_demo.c
@@ -304,7 +304,7 @@ static void* output_process(struct m0_buf *result, void *in_args,
 {
 	switch (type) {
 	case ICT_PING:
-		printf ("\nHello-%s@"FID_F "\n", (char *)result->b_addr,
+		printf ("Hello-%s@"FID_F"\n", (char *)result->b_addr,
 			FID_P((struct m0_fid *)op_args));
 		memset(result->b_addr, 'a', result->b_nob);
 		return NULL;
@@ -392,14 +392,15 @@ int main(int argc, char **argv)
 				   op_type, ip_args);
 		if (rc != 0) {
 			fprintf(stderr,
-				"\nerror! Input preparation failed: %d", rc);
+				"error! Input preparation failed: %d\n", rc);
 			break;
 		}
 		rc = c0appz_isc_req_prepare(&req, &buf, &comp_fid, &result,
 					    &svc_fid, reply_len);
 		if (rc != 0) {
-			fprintf(stderr, "\nerror! request preparation failed:"
-				"%d", rc);
+			m0_buf_free(&buf);
+			fprintf(stderr,
+				"error! request preparation failed: %d\n", rc);
 			goto out;
 		}
 		/*
@@ -431,11 +432,6 @@ int main(int argc, char **argv)
 	/* time out */
 	c0appz_timeout(0);
 
-	/* success */
-	if (rc == 0)
-		fprintf(stderr,"%s success\n", prog);
-	else
-		fprintf(stderr,"%s fail\n", prog);
 	return rc;
 }
 

--- a/c0isc_demo.c
+++ b/c0isc_demo.c
@@ -137,6 +137,8 @@ static int op_init(enum isc_comp_type type, void **ip_args)
 	case ICT_MIN:
 	case ICT_MAX:
 		M0_ALLOC_PTR(in_info);
+		if (in_info == NULL)
+			return -ENOMEM;
 		rc = file_to_array("c0isc_data", (void **)&arr, &arr_len);
 		if (rc != 0)
 			return rc;
@@ -154,19 +156,18 @@ static int op_init(enum isc_comp_type type, void **ip_args)
 	}
 }
 
-static void op_fini(enum isc_comp_type op_type, void *ip_args, void *op_args)
+static void op_fini(enum isc_comp_type op_type, struct mm_args *in_info,
+		    void *op_args)
 {
-	struct mm_args *in_info;
-
 	switch (op_type) {
 	case ICT_PING:
 		break;
 	case ICT_MIN:
 	case ICT_MAX:
-		if (ip_args == NULL)
+		if (in_info == NULL)
 			break;
-		in_info = ip_args;
 		m0_free(in_info->ma_arr);
+		m0_free(in_info);
 		m0_free(op_args);
 	}
 }


### PR DESCRIPTION
c0isc_demo does not return any result for min/max on a singlenode cluster:

```
$ ./c0isc_demo max
c0isc_demo success
```

Solution: fix bug at minmax_output_prepare().